### PR TITLE
feat: Actualizar tarea en DataGrid

### DIFF
--- a/src/api/task.js
+++ b/src/api/task.js
@@ -16,7 +16,7 @@ export const getAllTasks = async () => {
   // Función para actualizar una tarea por su ID
 export const updateTaskById = async (taskId, updatedTaskData) => {
     try {
-      const response = await axios.put(`/api/tasks/${taskId}`, updatedTaskData);
+      const response = await axios.put(`/tasks/${taskId}`, updatedTaskData);
       // Podrías realizar operaciones adicionales aquí después de la actualización
       return response.data;
     } catch (error) {

--- a/src/components/TaskCrud/components/DataGridTaskCrud/index.jsx
+++ b/src/components/TaskCrud/components/DataGridTaskCrud/index.jsx
@@ -1,18 +1,123 @@
 import React from "react";
-import { getAllTasks } from "../../../../api/task";
-import { DataGrid, GridActionsCellItem, GridToolbarColumnsButton, GridToolbarContainer, GridToolbarDensitySelector, GridToolbarExport, GridToolbarFilterButton } from "@mui/x-data-grid";
+import { getAllTasks, updateTaskById } from "../../../../api/task";
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridToolbarColumnsButton,
+  GridToolbarContainer,
+  GridToolbarDensitySelector,
+  GridToolbarExport,
+  GridToolbarFilterButton,
+} from "@mui/x-data-grid";
 import DeleteIcon from "@mui/icons-material/DeleteOutlined";
-import { IconButton } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Snackbar,
+} from "@mui/material";
 import CheckIcon from "@mui/icons-material/Check";
 import ClearIcon from "@mui/icons-material/Clear";
 import { getAllProcesses } from "../../../../api/process";
 
+/**
+ * Hook personalizado para simular una mutación asincrónica con datos ficticios.
+ *
+ * @param {Function} updateTaskById - Función para actualizar una tarea por ID utilizando la API.
+ * @returns {Function} - Función de retorno que realiza la mutación asincrónica.
+ *
+ * @throws {Error} - Se lanza un error si hay un problema durante la actualización.
+ *
+ * @async
+ * @function
+ * @name useFakeMutation
+ *
+ * @param {Object} task - Datos de la tarea para la mutación.
+ * @param {string} _action - Acción a realizar ("update", "delete", o "create").
+ * @returns {Promise<Object>} - Promesa que se resuelve con los datos resultantes de la mutación.
+ */
+const useFakeMutation = () => {
+  /**
+   * Función que realiza la mutación asincrónica.
+   *
+   * @async
+   *
+   * @param {Object} task - Datos de la tarea para la mutación.
+   * @param {string} _action - Acción a realizar ("update", "delete", o "create").
+   * @returns {Promise<Object>} - Promesa que se resuelve con los datos resultantes de la mutación.
+   *
+   * @throws {Error} - Se lanza un error si hay un problema durante la actualización.
+   */
+  return React.useCallback(async (task, _action) => {
+    try {
+      // Simulando una pausa de 200 ms con setTimeout
+      await new Promise((timeoutResolve) => setTimeout(timeoutResolve, 200));
 
+      const response = updateTaskById(task.id_tarea, task);
 
+      return response.data;
+    } catch (error) {
+      // Maneja errores de Axios o errores de validación
+      console.error(error);
+      throw error;
+    }
+  }, []);
+};
 
+/**
+ * Calcula la mutación necesaria para la actualización de una fila.
+ *
+ * @param {Object} newRow - La nueva fila con los datos actualizados.
+ * @param {Object} oldRow - La fila antigua con los datos originales.
+ * @returns {string|null} - Una cadena que describe la mutación, o null si no hay cambios.
+ */
+function computeMutation(newRow, oldRow) {
+  /**
+   * @typedef {Object} Mutation
+   * @property {string} [nameMutation] - Descripción de la mutación del nombre.
+   * @property {string} [activoMutation] - Descripción de la mutación del estado activo.
+   * @property {string} [procesoMutation] - Descripción de la mutación del proceso.
+   */
 
+  /** @type {Mutation} */
+  const mutation = {};
 
+  if (newRow.nombre !== oldRow.nombre) {
+    /**
+     * Descripción de la mutación del nombre.
+     * @type {string}
+     */
+    mutation.nameMutation = `¿Realmente quieres cambiar el nombre de '${oldRow.nombre}' a '${newRow.nombre}?'`;
+  }
 
+  if (newRow.activo !== oldRow.activo) {
+    /**
+     * Descripción de la mutación del estado activo.
+     * @type {string}
+     */
+    mutation.activoMutation = `¿Realmente deseas cambiar el estado de 'Activo' de '${
+      oldRow.activo ? "✅" : "❎" || ""
+    }' a '${newRow.activo ? "✅" : "❎" || ""}'?`;
+  }
+
+  if (newRow.id_proceso !== oldRow.id_proceso) {
+    /**
+     * Descripción de la mutación del proceso.
+     * @type {string}
+     */
+    mutation.procesoMutation = `¿Realmente quieres cambiar el proceso de '${oldRow.id_proceso || ""}' a '${
+      newRow.id_proceso || ""
+    }'?`;
+  }
+
+  // Devuelve la mutación completa o null si no hay cambios
+  return Object.values(mutation).join("\n") || null;
+}
 
 /**
  * Componente funcional que representa una celda de verificación.
@@ -57,11 +162,6 @@ const CheckCell = ({ data }) => {
  * <DataGridTaskCrud />
  */
 function DataGridTaskCrud() {
-
-
-
-
-  
   /**
    * Estado para almacenar las filas de datos.
    *
@@ -70,7 +170,22 @@ function DataGridTaskCrud() {
    * @private
    */
   const [rows, setRows] = React.useState([]);
-  const [getProcesses,setProcesses]=React.useState([])
+  const [getProcesses, setProcesses] = React.useState([]);
+  const mutateRow = useFakeMutation();
+  const noButtonRef = React.useRef(null);
+  const [promiseArguments, setPromiseArguments] = React.useState(null);
+  const [snackbar, setSnackbar] = React.useState(null);
+  /**
+   * Función que cierra el componente Snackbar.
+   *
+   * @function
+   * @name handleCloseSnackbar
+   *
+   * @description Esta función actualiza el estado del componente Snackbar para ocultarlo.
+   *
+   * @returns {void}
+   */
+  const handleCloseSnackbar = () => setSnackbar(null);
   /**
    * Construye y devuelve la configuración de columnas para el DataGrid.
    *
@@ -158,38 +273,33 @@ function DataGridTaskCrud() {
     return columns;
   };
 
-
-
-
   React.useEffect(() => {
     /**
-    * Función asíncrona para obtener y establecer los datos de las tareas.
-    *
-    * @function
-    * @async
-    * @private
-    */
-   const fetchData = async () => {
-     try {
-       // Aquí deberías hacer tu solicitud de red para obtener los datos
-       // Reemplaza 'TU_URL_DE_DATOS' con la URL real de tus datos
-       const response = await getAllTasks();
-  
-       
-  
-       // Agrega el campo 'id_tarea' a cada fila usando el índice como valor único si no no se ven en la datagrid
-       const rowsWithId = response.map((row, index) => ({
-         ...row,
-         id: row.id_tarea || index.toString(),
-       }));
-  
-       setRows(rowsWithId);
-     } catch (error) {
-       console.error("Error fetching data:", error);
-     }
-   };
-  
-   fetchData();
+     * Función asíncrona para obtener y establecer los datos de las tareas.
+     *
+     * @function
+     * @async
+     * @private
+     */
+    const fetchData = async () => {
+      try {
+        // Aquí deberías hacer tu solicitud de red para obtener los datos
+        // Reemplaza 'TU_URL_DE_DATOS' con la URL real de tus datos
+        const response = await getAllTasks();
+
+        // Agrega el campo 'id_tarea' a cada fila usando el índice como valor único si no no se ven en la datagrid
+        const rowsWithId = response.map((row, index) => ({
+          ...row,
+          id: row.id_tarea || index.toString(),
+        }));
+
+        setRows(rowsWithId);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    fetchData();
   }, []);
   /**
    * Hook de efecto para cargar datos iniciales al montar el componente.
@@ -199,7 +309,7 @@ function DataGridTaskCrud() {
    */
 
   React.useEffect(() => {
-     /**
+    /**
      * Función asíncrona para obtener y establecer los datos de las tareas.
      *
      * @function
@@ -213,16 +323,14 @@ function DataGridTaskCrud() {
         const response = await getAllProcesses();
 
         // Agrega el campo 'id_tarea' a cada fila usando el índice como valor único si no no se ven en la datagrid
-        const rowsWithId = response.map((row, index) => ({
-          ...row,
-          id: row.id_tarea || index.toString(),
-        })).filter((row)=>{
-          return row.activo
-        });
-
-
-       
-
+        const rowsWithId = response
+          .map((row, index) => ({
+            ...row,
+            id: row.id_tarea || index.toString(),
+          }))
+          .filter((row) => {
+            return row.activo;
+          });
 
         setProcesses(rowsWithId);
       } catch (error) {
@@ -232,27 +340,117 @@ function DataGridTaskCrud() {
 
     fetchData();
   }, []);
-
-   
-
-
-/**
- * Componente funcional que representa una barra de herramientas personalizada para un DataGrid.
- *
- * @component
- * @example
- * // Uso en un DataGrid
- * <DataGrid components={{ Toolbar: CustomToolbar }} />
- */
-   function CustomToolbar() {
-     /**
-   * Renderiza una barra de herramientas con botones para gestionar las columnas, filtros, densidad y exportación de un DataGrid.
+  /**
+   * Función que maneja la acción "No" en el contexto de una promesa.
    *
-   * @returns {JSX.Element} - Elemento JSX que representa la barra de herramientas personalizada.
+   * @function
+   * @name handleNo
+   *
+   * @description Esta función resuelve la promesa con la fila antigua para evitar la actualización del estado interno.
+   *
+   * @returns {void}
    */
-    
+  const handleNo = () => {
+    const { oldRow, resolve } = promiseArguments;
+    resolve(oldRow); // Resolve with the old row to not update the internal state
+    setPromiseArguments(null);
+  };
+/**
+ * Función que maneja la acción "Sí" en el contexto de una promesa al actualizar una tarea en el backend.
+ *
+ * @function
+ * @name handleYes
+ * @async
+ *
+ * @description Esta función realiza una solicitud HTTP para actualizar la tarea en el backend. 
+ * Si la solicitud tiene éxito, resuelve la promesa con la respuesta y muestra una notificación de éxito.
+ * Si hay un error, muestra una notificación de error, rechaza la promesa y utiliza la fila antigua para mantener el estado interno sin cambios.
+ * 
+ * @returns {Promise<void>}
+ */
+  const handleYes = async () => {
+    const { newRow, oldRow, reject, resolve } = promiseArguments;
 
- 
+    try {
+      // Make the HTTP request to save in the backend
+      const response = await mutateRow(newRow, "update");
+
+      setSnackbar({ children: "Tarea guardada exitosamente", severity: "success" });
+      resolve(response);
+      setPromiseArguments(null);
+    } catch (error) {
+      setSnackbar({ children: "Name can't be empty", severity: "error" });
+      reject(oldRow);
+      setPromiseArguments(null);
+    }
+   
+  };
+
+  const handleEntered = () => {
+    // The `autoFocus` is not used because, if used, the same Enter that saves
+    // the cell triggers "No". Instead, we manually focus the "No" button once
+    // the dialog is fully open.
+    // noButtonRef.current?.focus();
+  };
+
+
+  /**
+ * Función que renderiza un cuadro de diálogo de confirmación.
+ *
+ * @function
+ * @name renderConfirmDialog
+ *
+ * @description Esta función verifica si hay argumentos de promesa. Si los hay, utiliza la información
+ * de la promesa para calcular la mutación entre la fila nueva y antigua. Luego, renderiza un cuadro de diálogo
+ * de confirmación con la descripción de la mutación y botones "Sí" y "No" para confirmar o cancelar la acción.
+ *
+ * @returns {React.ReactElement|null} - Elemento de React que representa el cuadro de diálogo o `null` si no hay argumentos de promesa.
+ */
+  const renderConfirmDialog = () => {
+    if (!promiseArguments) {
+      return null;
+    }
+
+    const { newRow, oldRow } = promiseArguments;
+    const mutation = computeMutation(newRow, oldRow);
+
+    return (
+      <Dialog
+        maxWidth="xs"
+        TransitionProps={{ onEntered: handleEntered }}
+        open={!!promiseArguments}
+      >
+        <DialogTitle>¿Esta usted seguro?</DialogTitle>
+        <DialogContent dividers>
+          {`Presiona 'Ok' , si  ${mutation}.`}
+        </DialogContent>
+        <DialogActions>
+          <Button endIcon={<ClearIcon/>} color="secondary" ref={noButtonRef} onClick={handleNo}>
+            No
+          </Button>
+          <Button endIcon={<CheckIcon/>} color="secondary" onClick={handleYes}>
+            Ok
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  };
+
+  /**
+   * Componente funcional que representa una barra de herramientas personalizada para un DataGrid.
+   *
+   * @component
+   * @example
+   * // Uso en un DataGrid
+   * <DataGrid components={{ Toolbar: CustomToolbar }} />
+   */
+  function CustomToolbar() {
+    /**
+     * Renderiza una barra de herramientas con botones para gestionar las columnas, filtros, densidad y exportación de un DataGrid.
+     *
+     * @returns {JSX.Element} - Elemento JSX que representa la barra de herramientas personalizada.
+     */
+
     return (
       <GridToolbarContainer>
         <GridToolbarColumnsButton color="secondary" />
@@ -271,16 +469,65 @@ function DataGridTaskCrud() {
   }
 
   /**
+   * Función que procesa la actualización de una fila.
+   *
+   * @param {Object} newRow - La nueva fila con los datos actualizados.
+   * @param {Object} oldRow - La fila antigua con los datos originales.
+   * @returns {Promise<Object>} - Una promesa que se resolverá con la fila antigua si no hay cambios o con la fila actualizada si hay mutaciones.
+   * @throws {Error} - Se lanza un error si hay un problema durante la actualización.
+   */
+  const processRowUpdate = React.useCallback(
+    /**
+     * @param {Object} newRow - La nueva fila con los datos actualizados.
+     * @param {Object} oldRow - La fila antigua con los datos originales.
+     * @returns {Promise<Object>} - Una promesa que se resolverá con la fila antigua si no hay cambios o con la fila actualizada si hay mutaciones.
+     * @throws {Error} - Se lanza un error si hay un problema durante la actualización.
+     */
+    (newRow, oldRow) =>
+      new Promise((resolve, reject) => {
+        // Calcula la mutación necesaria para la actualización
+        const mutation = computeMutation(newRow, oldRow);
+
+        // Verifica si hay una mutación
+        if (mutation) {
+          // Guarda los argumentos para resolver o rechazar la promesa más tarde
+          setPromiseArguments({ resolve, reject, newRow, oldRow });
+        } else {
+          // No hubo cambios, resuelve la promesa con la fila antigua
+          resolve(oldRow);
+        }
+      }),
+    []
+  );
+
+  /**
    * Renderiza el componente DataGrid con las filas y columnas configuradas.
    *
    * @returns {JSX.Element} - Elemento JSX que representa el DataGrid.
    */
-  return <DataGrid rows={rows} columns={buildColumns()}   slots={{ toolbar: CustomToolbar }}  localeText={{
-    toolbarColumns: "Columnas",
-    toolbarFilters: "Filtros",
-    toolbarDensity: "Tamaño Celda",
-    toolbarExport: "Exportar",
-  }}/>;
+  return (
+    <Box style={{ height: 400, width: "100%" }}>
+      {renderConfirmDialog()}
+      <DataGrid
+        checkboxSelection
+        rows={rows}
+        columns={buildColumns()}
+        slots={{ toolbar: CustomToolbar }}
+        localeText={{
+          toolbarColumns: "Columnas",
+          toolbarFilters: "Filtros",
+          toolbarDensity: "Tamaño Celda",
+          toolbarExport: "Exportar",
+        }}
+        processRowUpdate={processRowUpdate}
+      />
+      {!!snackbar && (
+        <Snackbar open onClose={handleCloseSnackbar} autoHideDuration={6000}>
+          <Alert {...snackbar} onClose={handleCloseSnackbar} />
+        </Snackbar>
+      )}
+    </Box>
+  );
 }
 
 export default DataGridTaskCrud;


### PR DESCRIPTION
Se implementa la funcionalidad para actualizar una tarea en el DataGrid.
- Se añade la lógica para enviar una solicitud de actualización al backend.
- Se mejora la interfaz de usuario para reflejar los cambios realizados.

Este commit aborda la tarea [Número de tarea o ID] y mejora la capacidad de actualizar información directamente desde el DataGrid.