### PR TITLE
Manejar evento de clic para eliminar tarea

### DIFF
--- a/src/api/task.js
+++ b/src/api/task.js
@@ -28,8 +28,11 @@ export const updateTaskById = async (taskId, updatedTaskData) => {
 
 // Función para eliminar una tarea por su ID
 export const deleteTaskById = async (taskId) => {
+
+  
+           
     try {
-      const response = await axios.delete(`/api/tasks/${taskId}`);
+      const response = await axios.delete(`/tasks/${taskId}`);
       // Podrías realizar operaciones adicionales aquí después de la eliminación
       return response.data;
     } catch (error) {

--- a/src/components/TaskCrud/components/DataGridTaskCrud/index.jsx
+++ b/src/components/TaskCrud/components/DataGridTaskCrud/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getAllTasks, updateTaskById } from "../../../../api/task";
+import { deleteTaskById, getAllTasks, updateTaskById } from "../../../../api/task";
 import {
   DataGrid,
   GridActionsCellItem,
@@ -110,9 +110,9 @@ function computeMutation(newRow, oldRow) {
      * Descripción de la mutación del proceso.
      * @type {string}
      */
-    mutation.procesoMutation = `¿Realmente quieres cambiar el proceso de '${oldRow.id_proceso || ""}' a '${
-      newRow.id_proceso || ""
-    }'?`;
+    mutation.procesoMutation = `¿Realmente quieres cambiar el proceso de '${
+      oldRow.id_proceso || ""
+    }' a '${newRow.id_proceso || ""}'?`;
   }
 
   // Devuelve la mutación completa o null si no hay cambios
@@ -262,7 +262,7 @@ function DataGridTaskCrud() {
             <GridActionsCellItem
               icon={<DeleteIcon />}
               label="Delete"
-              /* onClick={() => handleDeleteClick(id)} */
+              onClick={() => handleDeleteClick(id)} 
               color="inherit"
             />,
           ];
@@ -340,6 +340,44 @@ function DataGridTaskCrud() {
 
     fetchData();
   }, []);
+
+  /**
+ * Maneja el evento de clic para eliminar una tarea.
+ *
+ * @async
+ * @function
+ * @name handleDeleteClick
+ *
+ * @param {string} id - El identificador único de la tarea que se va a eliminar.
+ * @returns {Promise<void>} - Una promesa que se resuelve después de intentar eliminar la tarea.
+ *
+ * @throws {Error} - Se lanza un error si hay un problema al intentar eliminar la tarea.
+ *
+ * @description Esta función realiza una solicitud HTTP para eliminar la tarea con el identificador proporcionado.
+ * Si la solicitud tiene éxito, muestra un mensaje en el Snackbar indicando que la tarea se ha eliminado correctamente.
+ * Si hay un error durante el proceso, muestra un mensaje de error en el Snackbar.
+ */
+const handleDeleteClick = async (id) => {
+  try {
+    // Realizar la solicitud HTTP para eliminar la tarea en el backend
+    const response = await deleteTaskById(id);
+    console.log(response);
+
+    // Mostrar un mensaje en el Snackbar después de la eliminación exitosa
+    setSnackbar({
+      children: "Tarea eliminada exitosamente",
+      severity: "success",
+    });
+  } catch (error) {
+    // Mostrar un mensaje de error en el Snackbar si hay un problema al eliminar la tarea
+    setSnackbar({
+      children: "Error al eliminar la tarea",
+      severity: "error",
+    });
+    console.error("Error al eliminar la tarea:", error);
+    throw error; // Relanzar el error para que pueda ser manejado en otras partes de la aplicación si es necesario
+  }
+};
   /**
    * Función que maneja la acción "No" en el contexto de una promesa.
    *
@@ -355,19 +393,19 @@ function DataGridTaskCrud() {
     resolve(oldRow); // Resolve with the old row to not update the internal state
     setPromiseArguments(null);
   };
-/**
- * Función que maneja la acción "Sí" en el contexto de una promesa al actualizar una tarea en el backend.
- *
- * @function
- * @name handleYes
- * @async
- *
- * @description Esta función realiza una solicitud HTTP para actualizar la tarea en el backend. 
- * Si la solicitud tiene éxito, resuelve la promesa con la respuesta y muestra una notificación de éxito.
- * Si hay un error, muestra una notificación de error, rechaza la promesa y utiliza la fila antigua para mantener el estado interno sin cambios.
- * 
- * @returns {Promise<void>}
- */
+  /**
+   * Función que maneja la acción "Sí" en el contexto de una promesa al actualizar una tarea en el backend.
+   *
+   * @function
+   * @name handleYes
+   * @async
+   *
+   * @description Esta función realiza una solicitud HTTP para actualizar la tarea en el backend.
+   * Si la solicitud tiene éxito, resuelve la promesa con la respuesta y muestra una notificación de éxito.
+   * Si hay un error, muestra una notificación de error, rechaza la promesa y utiliza la fila antigua para mantener el estado interno sin cambios.
+   *
+   * @returns {Promise<void>}
+   */
   const handleYes = async () => {
     const { newRow, oldRow, reject, resolve } = promiseArguments;
 
@@ -375,7 +413,10 @@ function DataGridTaskCrud() {
       // Make the HTTP request to save in the backend
       const response = await mutateRow(newRow, "update");
 
-      setSnackbar({ children: "Tarea guardada exitosamente", severity: "success" });
+      setSnackbar({
+        children: "Tarea guardada exitosamente",
+        severity: "success",
+      });
       resolve(response);
       setPromiseArguments(null);
     } catch (error) {
@@ -383,7 +424,6 @@ function DataGridTaskCrud() {
       reject(oldRow);
       setPromiseArguments(null);
     }
-   
   };
 
   const handleEntered = () => {
@@ -393,19 +433,18 @@ function DataGridTaskCrud() {
     // noButtonRef.current?.focus();
   };
 
-
   /**
- * Función que renderiza un cuadro de diálogo de confirmación.
- *
- * @function
- * @name renderConfirmDialog
- *
- * @description Esta función verifica si hay argumentos de promesa. Si los hay, utiliza la información
- * de la promesa para calcular la mutación entre la fila nueva y antigua. Luego, renderiza un cuadro de diálogo
- * de confirmación con la descripción de la mutación y botones "Sí" y "No" para confirmar o cancelar la acción.
- *
- * @returns {React.ReactElement|null} - Elemento de React que representa el cuadro de diálogo o `null` si no hay argumentos de promesa.
- */
+   * Función que renderiza un cuadro de diálogo de confirmación.
+   *
+   * @function
+   * @name renderConfirmDialog
+   *
+   * @description Esta función verifica si hay argumentos de promesa. Si los hay, utiliza la información
+   * de la promesa para calcular la mutación entre la fila nueva y antigua. Luego, renderiza un cuadro de diálogo
+   * de confirmación con la descripción de la mutación y botones "Sí" y "No" para confirmar o cancelar la acción.
+   *
+   * @returns {React.ReactElement|null} - Elemento de React que representa el cuadro de diálogo o `null` si no hay argumentos de promesa.
+   */
   const renderConfirmDialog = () => {
     if (!promiseArguments) {
       return null;
@@ -425,10 +464,15 @@ function DataGridTaskCrud() {
           {`Presiona 'Ok' , si  ${mutation}.`}
         </DialogContent>
         <DialogActions>
-          <Button endIcon={<ClearIcon/>} color="secondary" ref={noButtonRef} onClick={handleNo}>
+          <Button
+            endIcon={<ClearIcon />}
+            color="secondary"
+            ref={noButtonRef}
+            onClick={handleNo}
+          >
             No
           </Button>
-          <Button endIcon={<CheckIcon/>} color="secondary" onClick={handleYes}>
+          <Button endIcon={<CheckIcon />} color="secondary" onClick={handleYes}>
             Ok
           </Button>
         </DialogActions>


### PR DESCRIPTION
Esta actualización incluye la función 'handleDeleteClick' que maneja el evento de clic para eliminar una tarea. La función realiza una solicitud HTTP para eliminar la tarea con el identificador proporcionado y muestra mensajes en el Snackbar para indicar el resultado de la operación (éxito o error). Se documentó la función con JSDoc para facilitar la comprensión y mantenimiento del código.