### PR TITLE
feat: Crear Tarea - Frontend

### DIFF
--- a/src/api/task.js
+++ b/src/api/task.js
@@ -44,7 +44,7 @@ export const deleteTaskById = async (taskId) => {
   // Función para crear una nueva tarea
   export const createTask = async (taskData) => {
     try {
-      const response = await axios.post('/api/task', taskData);
+      const response = await axios.post('/task', taskData);
       // Podrías realizar operaciones adicionales aquí después de la creación
       return response.data;
     } catch (error) {


### PR DESCRIPTION
Agrega funcionalidad para crear una tarea en el frontend. Se implementa la lógica en la interfaz de usuario para capturar los datos necesarios, realizar una solicitud HTTP para crear la tarea en el servidor y manejar las respuestas del servidor. Se añaden validaciones de entrada y mensajes de notificación para mejorar la experiencia del usuario.