### PR TITLE
feat: Agregar página de gestión de servicios

### DIFF
--- a/src/scenes/service/index.jsx
+++ b/src/scenes/service/index.jsx
@@ -1,0 +1,26 @@
+import { Box, useTheme } from '@mui/material';
+import React from 'react'
+import { useSelector } from 'react-redux';
+import { tokens } from '../../theme';
+import Header from '../../components/Header';
+/**
+ * Página principal para la gestión de servicios.
+ *
+ * @component
+ * @returns {JSX.Element} - Elemento JSX que representa la página de gestión de servicios.
+ */
+function Service() {
+  const user = useSelector((state) => state.user);
+  const theme = useTheme();
+  const colors = tokens(theme.palette.mode);
+console.log("prueba");
+  return (
+    <Box m="20px">
+    <Header title="Gestiòn de Servicios" subtitle="Operaciones de Crear, Leer, Actualizar y Eliminar Servicios en el Sistema" />
+ ServiceCrud
+    
+  </Box>
+  )
+}
+
+export default Service


### PR DESCRIPTION
Agrega la página principal para la gestión de servicios. Incluye un encabezado con título y subtítulo, y utiliza Redux para obtener el estado del usuario. También utiliza Material-UI para temas y colores. Se ha comentado la línea que incluiría el componente 'ServiceCrud', ya que parece estar incompleta o faltante en el código original.