### PR TITLE
Implementar diálogo para cambiar imagen en la DataGrid

### DIFF
--- a/src/api/process.js
+++ b/src/api/process.js
@@ -46,6 +46,7 @@ export const createProcess = async (processData) => {
    * @throws {Error} - Error en caso de fallo durante la actualización del proceso.
    */
   export const updateProcess = async (processId, updatedData) => {
+    console.log(updatedData);
     try {
       const response = await axios.put(`/processes/${processId}`, updatedData);
       return response.data;


### PR DESCRIPTION
Se añadió funcionalidad para abrir un diálogo al hacer clic en la imagen en la DataGrid. Este diálogo permite al usuario seleccionar y cambiar la imagen asociada a un proceso. Se utilizó un componente Avatar para mostrar la imagen actual y se incluyó un campo de carga de archivo para seleccionar una nueva imagen. La lógica de manejo de archivos se integró con el servicio de almacenamiento en la nube (S3). Además, se mejoró la interfaz del usuario al mostrar una vista previa de la imagen seleccionada en el diálogo antes de confirmar el cambio.