### PR TITLE
Añade tamaño 'small' al botón de 'Agregar Nuevo Servicio'

### DIFF
--- a/src/components/ServiceCrud/components/DataGridServiceCrud/index.jsx
+++ b/src/components/ServiceCrud/components/DataGridServiceCrud/index.jsx
@@ -972,6 +972,7 @@ const handleFileChangeWebImage = async (event) => {
           color="secondary"
           onClick={handleOpenNewServiceDialog}
           startIcon={<AddOutlined />}
+          size="small"
         >
           Agregar Nuevo Servicio
         </Button>
@@ -1406,6 +1407,7 @@ const handleFileChangeWebImage = async (event) => {
                   color="secondary"
                   variant="contained"
                   onClick={handleAddService}
+                 
                 >
                   Guardar Servicio
                 </Button>


### PR DESCRIPTION
En este commit, se ha añadido la propiedad 'size' al componente Button de Material-UI en la sección de 'Agregar Nuevo Servicio'. La propiedad 'size' se ha configurado como 'small' para mejorar la apariencia y consistencia visual del botón.

Detalles de los cambios:
- Añadida la propiedad 'size' con el valor 'small' al componente Button.
- Se ha ajustado el botón 'Agregar Nuevo Servicio' para reflejar el cambio en el tamaño.