### PR TITLE
Añadida ruta para el componente 'Roles'

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,6 @@ import Login from './scenes/login'
 import NewUser from './scenes/new-user'
 import MapList from './scenes/maps'
 import Map from './scenes/map'
-import Roles from './scenes/roles'
 import Maintenance from './scenes/maintenance'
 import WorkAssignment from './scenes/work-assignment'
 import DashboardCoordinator from './scenes/dashboard-coordinacion'
@@ -42,6 +41,7 @@ import ValidPayment from './scenes/valid-payment'
 import Task from "./scenes/task";
 import Service from "./scenes/service";
 import Process from "./scenes/process";
+import Roles from "./scenes/roles"
 
 
 
@@ -135,7 +135,7 @@ function App() {
                     <Route path="/new-user" element={<NewUser />} />
                     <Route path="/map-list" element={<MapList />} />
                     <Route path="/map/:place_id" element={<Map />} />
-                    <Route path="/roles" element={<Roles />} />
+                    <Route path="/roles" element={<Roles/>} />
                     <Route path="/maintenance" element={<Maintenance />} />
                     <Route path="/work-assignment" element={<WorkAssignment />} />
                     <Route path="/dashboard-coordinator" element={<DashboardCoordinator />} />

--- a/src/components/RolCrud/index.jsx
+++ b/src/components/RolCrud/index.jsx
@@ -1,5 +1,6 @@
-import { Container } from '@mui/material'
+
 import React from 'react'
+import Container from '../Container'
 /**
  * Componente que representa la funcionalidad CRUD para roles.
  * Este componente utiliza un contenedor para organizar su contenido.

--- a/src/scenes/roles/index.jsx
+++ b/src/scenes/roles/index.jsx
@@ -160,7 +160,19 @@ import React from 'react'
 import Header from '../../components/Header';
 import { useSelector } from 'react-redux';
 import { tokens } from '../../theme';
-
+import RolCrud from '../../components/RolCrud';
+/**
+ * Componente que representa la gestión de roles en el sistema.
+ *
+ * @component
+ * @example
+ * // Uso del componente 'Roles' en otro componente o archivo.
+ * import Roles from './Roles';
+ * // ...
+ * <Roles />
+ *
+ * @returns {JSX.Element} Elemento JSX que contiene la interfaz de usuario para la gestión de roles.
+ */
 function Roles() {
     const user = useSelector((state) => state.user);
   const theme = useTheme();
@@ -168,7 +180,7 @@ function Roles() {
   return (
     <Box m="20px">
     <Header title="Gestiòn de Roles" subtitle="Operaciones de Crear, Leer, Actualizar y Eliminar Roles en el Sistema" />
- ServiceCrud
+ <RolCrud/>
     
   </Box>
   )


### PR DESCRIPTION
Se configuró una nueva ruta en el archivo de enrutamiento para que el componente 'Roles' sea renderizado cuando la URL coincida con "/roles". Esto permite la navegación a la página de gestión de roles dentro de la aplicación.